### PR TITLE
feat: add navigation and notifications

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,34 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { RouterLink, RouterView } from 'vue-router'
+import GlobalNotification from '@/components/GlobalNotification.vue'
+</script>
 
 <template>
-  <h1>You did it!</h1>
-  <p>
-    Visit <a href="https://vuejs.org/" target="_blank" rel="noopener">vuejs.org</a> to read the
-    documentation
-  </p>
+  <div>
+    <nav>
+      <RouterLink to="/login">Login</RouterLink>
+      <RouterLink to="/register">Register</RouterLink>
+      <RouterLink to="/recipes">Recipes</RouterLink>
+    </nav>
+    <GlobalNotification />
+    <RouterView />
+  </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+nav {
+  background-color: #f0f0f0;
+  padding: 1rem;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #333;
+  text-decoration: none;
+}
+
+nav a.router-link-exact-active {
+  font-weight: bold;
+}
+</style>

--- a/src/__tests__/App.spec.ts
+++ b/src/__tests__/App.spec.ts
@@ -1,11 +1,26 @@
 import { describe, it, expect } from 'vitest'
-
 import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import router from '../router'
 import App from '../App.vue'
 
 describe('App', () => {
-  it('mounts renders properly', () => {
-    const wrapper = mount(App)
-    expect(wrapper.text()).toContain('You did it!')
+  it('renders navigation links', async () => {
+    router.push('/')
+    await router.isReady()
+
+    const pinia = createPinia()
+    const wrapper = mount(App, {
+      global: {
+        plugins: [pinia, router],
+      },
+    })
+
+    const linkTexts = wrapper
+      .findAll('nav a')
+      .map((a) => a.text())
+    expect(linkTexts).toContain('Login')
+    expect(linkTexts).toContain('Register')
+    expect(linkTexts).toContain('Recipes')
   })
 })

--- a/src/components/GlobalNotification.vue
+++ b/src/components/GlobalNotification.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useNotificationStore } from '@/stores/notification'
+
+const notificationStore = useNotificationStore()
+const { message } = storeToRefs(notificationStore)
+</script>
+
+<template>
+  <div v-if="message" class="notification">{{ message }}</div>
+</template>
+
+<style scoped>
+.notification {
+  background-color: #f56565;
+  color: #fff;
+  padding: 1rem;
+  margin: 1rem;
+  border-radius: 4px;
+}
+</style>

--- a/src/stores/notification.ts
+++ b/src/stores/notification.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+
+export const useNotificationStore = defineStore('notification', {
+  state: () => ({
+    message: '' as string,
+  }),
+  actions: {
+    setError(message: string) {
+      this.message = message
+    },
+    clear() {
+      this.message = ''
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add navigation bar and router view to root app
- show global notification for API errors
- test navigation links rendering

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a27d15b86483338afd5e920cd0f5a6