### PR TITLE
Implement functional recipe CRUD views

### DIFF
--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,4 +1,4 @@
-import { setupWorker } from 'msw'
+import { setupWorker } from 'msw/browser'
 import { handlers } from './handlers'
 
 export const worker = setupWorker(...handlers)

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -20,10 +20,31 @@ const handlers = [
       { id: 2, name: 'Sugar' },
     ]),
   ),
-  http.get('/api/v1/recipes', () =>
-    HttpResponse.json([
+  http.get('/api/v1/recipes', ({ request }) => {
+    const url = new URL(request.url)
+    const term = url.searchParams.get('search')
+    const recipes = [
       { id: 1, name: 'Pancakes', description: 'Fluffy breakfast treat' },
-    ]),
+      { id: 2, name: 'Waffles', description: 'Crispy treat' },
+    ]
+    const filtered = term
+      ? recipes.filter(r => r.name.toLowerCase().includes(term.toLowerCase()))
+      : recipes
+    return HttpResponse.json(filtered)
+  }),
+  http.get('/api/v1/recipes/:id', ({ params }) =>
+    HttpResponse.json({ id: Number(params.id), name: 'Pancakes', description: 'Fluffy breakfast treat' }),
+  ),
+  http.post('/api/v1/recipes', async ({ request }) => {
+    const body: any = await request.json()
+    return HttpResponse.json({ id: 2, ...body.data?.attributes })
+  }),
+  http.patch('/api/v1/recipes/:id', async ({ params, request }) => {
+    const body: any = await request.json()
+    return HttpResponse.json({ id: Number(params.id), ...body.data?.attributes })
+  }),
+  http.delete('/api/v1/recipes/:id', () =>
+    HttpResponse.json({ message: 'Recipe deleted' }),
   ),
   http.get('/api/v1/steps', () =>
     HttpResponse.json([

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,8 @@ import Login from '@/views/Login.vue'
 import Register from '@/views/Register.vue'
 import RecipeList from '@/views/RecipeList.vue'
 import RecipeForm from '@/views/RecipeForm.vue'
+import RecipeSearch from '@/views/RecipeSearch.vue'
+import RecipeDelete from '@/views/RecipeDelete.vue'
 import NotFound from '@/views/NotFound.vue'
 
 const isAuthenticated = () => !!localStorage.getItem('token')
@@ -25,9 +27,21 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/recipes/search',
+      name: 'recipe-search',
+      component: RecipeSearch,
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/recipes/:id/edit',
       name: 'recipe-edit',
       component: RecipeForm,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/recipes/:id/delete',
+      name: 'recipe-delete',
+      component: RecipeDelete,
       meta: { requiresAuth: true },
     },
     { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFound },

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -18,7 +18,8 @@ export interface RecipePayload {
   }
 }
 
-export const getRecipes = () => api.get('/api/v1/recipes')
+export const getRecipes = (search?: string) =>
+  api.get('/api/v1/recipes', { params: { search } })
 
 export const getRecipe = (id: number, include?: string) =>
   api.get(`/api/v1/recipes/${id}`, { params: { include } })

--- a/src/views/RecipeDelete.vue
+++ b/src/views/RecipeDelete.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+import { deleteRecipe } from '@/services/recipeService'
+
+defineOptions({ name: 'RecipeDeleteView' })
+
+const route = useRoute()
+const router = useRouter()
+const id = Number(route.params.id)
+
+const remove = async () => {
+  await deleteRecipe(id)
+  router.push({ name: 'recipes' })
+}
+</script>
+
+<template>
+  <div>
+    <h1>Delete Recipe</h1>
+    <p>Are you sure you want to delete this recipe?</p>
+    <button @click="remove">Delete</button>
+    <router-link :to="{ name: 'recipes' }">Cancel</router-link>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/views/RecipeForm.vue
+++ b/src/views/RecipeForm.vue
@@ -1,9 +1,60 @@
 <script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getRecipe, createRecipe, updateRecipe } from '@/services/recipeService'
+
 defineOptions({ name: 'RecipeFormView' })
+
+const route = useRoute()
+const router = useRouter()
+
+const id = route.params.id ? Number(route.params.id) : null
+const name = ref('')
+const description = ref('')
+
+onMounted(async () => {
+  if (id) {
+    const { data } = await getRecipe(id)
+    name.value = data.name
+    description.value = data.description
+  }
+})
+
+const submit = async () => {
+  const payload = {
+    data: {
+      attributes: {
+        name: name.value,
+        description: description.value,
+      },
+    },
+  }
+
+  if (id) {
+    await updateRecipe(id, payload)
+  } else {
+    await createRecipe(payload)
+  }
+
+  router.push({ name: 'recipes' })
+}
 </script>
 
 <template>
-  <h1>Recipe Form</h1>
+  <div>
+    <h1>{{ id ? 'Edit' : 'Create' }} Recipe</h1>
+    <form @submit.prevent="submit">
+      <div>
+        <label for="name">Name</label>
+        <input id="name" v-model="name" required />
+      </div>
+      <div>
+        <label for="description">Description</label>
+        <textarea id="description" v-model="description"></textarea>
+      </div>
+      <button type="submit">Save</button>
+    </form>
+  </div>
 </template>
 
 <style scoped></style>

--- a/src/views/RecipeList.vue
+++ b/src/views/RecipeList.vue
@@ -1,9 +1,36 @@
 <script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { getRecipes } from '@/services/recipeService'
+
 defineOptions({ name: 'RecipeListView' })
+
+interface Recipe {
+  id: number
+  name: string
+  description: string
+}
+
+const recipes = ref<Recipe[]>([])
+
+onMounted(async () => {
+  const { data } = await getRecipes()
+  recipes.value = data
+})
 </script>
 
 <template>
-  <h1>Recipes</h1>
+  <div>
+    <h1>Recipes</h1>
+    <router-link to="/recipes/new">Create Recipe</router-link>
+    <ul>
+      <li v-for="recipe in recipes" :key="recipe.id">
+        {{ recipe.name }}
+        <router-link :to="`/recipes/${recipe.id}/edit`">Edit</router-link>
+        <router-link :to="`/recipes/${recipe.id}/delete`">Delete</router-link>
+      </li>
+    </ul>
+    <router-link to="/recipes/search">Search Recipes</router-link>
+  </div>
 </template>
 
 <style scoped></style>

--- a/src/views/RecipeSearch.vue
+++ b/src/views/RecipeSearch.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { getRecipes } from '@/services/recipeService'
+
+defineOptions({ name: 'RecipeSearchView' })
+
+interface Recipe {
+  id: number
+  name: string
+  description: string
+}
+
+const query = ref('')
+const results = ref<Recipe[]>([])
+
+const search = async () => {
+  if (!query.value) {
+    results.value = []
+    return
+  }
+  const { data } = await getRecipes(query.value)
+  results.value = data
+}
+</script>
+
+<template>
+  <div>
+    <h1>Search Recipes</h1>
+    <input v-model="query" placeholder="Search by name" />
+    <button @click="search">Search</button>
+    <ul>
+      <li v-for="recipe in results" :key="recipe.id">
+        {{ recipe.name }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- add recipe list view displaying and linking to full CRUD pages
- implement forms for creating, updating, searching, and deleting recipes
- extend recipe service and mocks to support search and mutation endpoints

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a533fa1988833394408daaaf79650e