### PR TITLE
Add login and registration pages

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,56 +1,72 @@
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse } from "msw";
+
+interface RecipeRequest {
+  data?: {
+    attributes?: Record<string, unknown>;
+  };
+}
 
 const handlers = [
-  http.post('/api/register', () =>
-    HttpResponse.json({ message: 'User registered', data: { token: 'mock-token' } }),
+  http.post("/api/register", () =>
+    HttpResponse.json({
+      message: "User registered",
+      data: { token: "mock-token" },
+    }),
   ),
-  http.post('/api/login', () =>
-    HttpResponse.json({ message: 'Logged in', data: { token: 'mock-token' } }),
+  http.post("/api/login", () =>
+    HttpResponse.json({ message: "Logged in", data: { token: "mock-token" } }),
   ),
-  http.post('/api/logout', () => HttpResponse.json({ message: 'Logged out' })),
-  http.get('/api/v1/authors', () =>
+  http.post("/api/logout", () => HttpResponse.json({ message: "Logged out" })),
+  http.get("/api/v1/authors", () =>
     HttpResponse.json([
-      { id: 1, name: 'Alice', email: 'alice@example.com' },
-      { id: 2, name: 'Bob', email: 'bob@example.com' },
+      { id: 1, name: "Alice", email: "alice@example.com" },
+      { id: 2, name: "Bob", email: "bob@example.com" },
     ]),
   ),
-  http.get('/api/v1/ingredients', () =>
+  http.get("/api/v1/ingredients", () =>
     HttpResponse.json([
-      { id: 1, name: 'Flour' },
-      { id: 2, name: 'Sugar' },
+      { id: 1, name: "Flour" },
+      { id: 2, name: "Sugar" },
     ]),
   ),
-  http.get('/api/v1/recipes', ({ request }) => {
-    const url = new URL(request.url)
-    const term = url.searchParams.get('search')
+  http.get("/api/v1/recipes", ({ request }) => {
+    const url = new URL(request.url);
+    const term = url.searchParams.get("search");
     const recipes = [
-      { id: 1, name: 'Pancakes', description: 'Fluffy breakfast treat' },
-      { id: 2, name: 'Waffles', description: 'Crispy treat' },
-    ]
+      { id: 1, name: "Pancakes", description: "Fluffy breakfast treat" },
+      { id: 2, name: "Waffles", description: "Crispy treat" },
+    ];
     const filtered = term
-      ? recipes.filter(r => r.name.toLowerCase().includes(term.toLowerCase()))
-      : recipes
-    return HttpResponse.json(filtered)
+      ? recipes.filter((r) => r.name.toLowerCase().includes(term.toLowerCase()))
+      : recipes;
+    return HttpResponse.json(filtered);
   }),
-  http.get('/api/v1/recipes/:id', ({ params }) =>
-    HttpResponse.json({ id: Number(params.id), name: 'Pancakes', description: 'Fluffy breakfast treat' }),
+  http.get("/api/v1/recipes/:id", ({ params }) =>
+    HttpResponse.json({
+      id: Number(params.id),
+      name: "Pancakes",
+      description: "Fluffy breakfast treat",
+    }),
   ),
-  http.post('/api/v1/recipes', async ({ request }) => {
-    const body: any = await request.json()
-    return HttpResponse.json({ id: 2, ...body.data?.attributes })
+  http.post("/api/v1/recipes", async ({ request }) => {
+    const body = (await request.json()) as RecipeRequest;
+    return HttpResponse.json({ id: 2, ...(body.data?.attributes ?? {}) });
   }),
-  http.patch('/api/v1/recipes/:id', async ({ params, request }) => {
-    const body: any = await request.json()
-    return HttpResponse.json({ id: Number(params.id), ...body.data?.attributes })
+  http.patch("/api/v1/recipes/:id", async ({ params, request }) => {
+    const body = (await request.json()) as RecipeRequest;
+    return HttpResponse.json({
+      id: Number(params.id),
+      ...(body.data?.attributes ?? {}),
+    });
   }),
-  http.delete('/api/v1/recipes/:id', () =>
-    HttpResponse.json({ message: 'Recipe deleted' }),
+  http.delete("/api/v1/recipes/:id", () =>
+    HttpResponse.json({ message: "Recipe deleted" }),
   ),
-  http.get('/api/v1/steps', () =>
+  http.get("/api/v1/steps", () =>
     HttpResponse.json([
-      { id: 1, step: 1, description: 'Mix dry ingredients', optional: false },
+      { id: 1, step: 1, description: "Mix dry ingredients", optional: false },
     ]),
   ),
-]
+];
 
-export { handlers }
+export { handlers };

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,35 +1,47 @@
-import { defineStore } from 'pinia'
+import { defineStore } from "pinia";
 import {
   login as loginRequest,
   logout as logoutRequest,
+  register as registerRequest,
   type LoginPayload,
-} from '@/services/authService'
+  type RegisterPayload,
+} from "@/services/authService";
 
 interface User {
-  email: string
+  email: string;
 }
 
-export const useAuthStore = defineStore('auth', {
+export const useAuthStore = defineStore("auth", {
   state: () => ({
     user: null as User | null,
-    token: localStorage.getItem('token') as string | null,
+    token: localStorage.getItem("token") as string | null,
   }),
   actions: {
     async login(payload: LoginPayload) {
-      const response = await loginRequest(payload)
-      const token = response.data?.data?.token
+      const response = await loginRequest(payload);
+      const token = response.data?.data?.token;
       if (token) {
-        this.token = token
-        localStorage.setItem('token', token)
+        this.token = token;
+        localStorage.setItem("token", token);
       }
-      this.user = { email: payload.email }
-      return response
+      this.user = { email: payload.email };
+      return response;
+    },
+    async register(payload: RegisterPayload) {
+      const response = await registerRequest(payload);
+      const token = response.data?.data?.token;
+      if (token) {
+        this.token = token;
+        localStorage.setItem("token", token);
+      }
+      this.user = { email: payload.email };
+      return response;
     },
     async logout() {
-      await logoutRequest()
-      this.user = null
-      this.token = null
-      localStorage.removeItem('token')
+      await logoutRequest();
+      this.user = null;
+      this.token = null;
+      localStorage.removeItem("token");
     },
   },
-})
+});

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,9 +1,44 @@
 <script setup lang="ts">
-defineOptions({ name: 'LoginView' })
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/authStore";
+import { useNotificationStore } from "@/stores/notification";
+
+defineOptions({ name: "LoginView" });
+
+const email = ref("");
+const password = ref("");
+
+const router = useRouter();
+const authStore = useAuthStore();
+const notification = useNotificationStore();
+
+const submit = async () => {
+  notification.clear();
+  try {
+    await authStore.login({ email: email.value, password: password.value });
+    router.push({ name: "recipes" });
+  } catch {
+    notification.setError("Login failed");
+  }
+};
 </script>
 
 <template>
-  <h1>Login</h1>
+  <div>
+    <h1>Login</h1>
+    <form @submit.prevent="submit">
+      <div>
+        <label for="email">Email</label>
+        <input id="email" type="email" v-model="email" required />
+      </div>
+      <div>
+        <label for="password">Password</label>
+        <input id="password" type="password" v-model="password" required />
+      </div>
+      <button type="submit">Login</button>
+    </form>
+  </div>
 </template>
 
 <style scoped></style>

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -1,9 +1,64 @@
 <script setup lang="ts">
-defineOptions({ name: 'RegisterView' })
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/authStore";
+import { useNotificationStore } from "@/stores/notification";
+
+defineOptions({ name: "RegisterView" });
+
+const name = ref("");
+const email = ref("");
+const password = ref("");
+const passwordConfirmation = ref("");
+
+const router = useRouter();
+const authStore = useAuthStore();
+const notification = useNotificationStore();
+
+const submit = async () => {
+  notification.clear();
+  try {
+    await authStore.register({
+      name: name.value,
+      email: email.value,
+      password: password.value,
+      password_confirmation: passwordConfirmation.value,
+    });
+    router.push({ name: "recipes" });
+  } catch {
+    notification.setError("Registration failed");
+  }
+};
 </script>
 
 <template>
-  <h1>Register</h1>
+  <div>
+    <h1>Register</h1>
+    <form @submit.prevent="submit">
+      <div>
+        <label for="name">Name</label>
+        <input id="name" v-model="name" required />
+      </div>
+      <div>
+        <label for="email">Email</label>
+        <input id="email" type="email" v-model="email" required />
+      </div>
+      <div>
+        <label for="password">Password</label>
+        <input id="password" type="password" v-model="password" required />
+      </div>
+      <div>
+        <label for="password_confirmation">Confirm Password</label>
+        <input
+          id="password_confirmation"
+          type="password"
+          v-model="passwordConfirmation"
+          required
+        />
+      </div>
+      <button type="submit">Register</button>
+    </form>
+  </div>
 </template>
 
 <style scoped></style>


### PR DESCRIPTION
## Summary
- implement register action and token storage
- create login and registration views wired to API
- type-safe recipe request handling in mocks

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a53cf5d4f88333a6e1c1088d93c6ba