### PR TITLE
feat: support steps and ingredients for recipes

### DIFF
--- a/src/__tests__/RecipeForm.spec.ts
+++ b/src/__tests__/RecipeForm.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import RecipeForm from "@/views/RecipeForm.vue";
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ params: {} }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe("RecipeForm", () => {
+  it("renders fields for estimated time, ingredients and steps", () => {
+    const wrapper = mount(RecipeForm);
+    expect(wrapper.find("#estimatedTime").exists()).toBe(true);
+    expect(wrapper.find("#ingredient-0").exists()).toBe(true);
+    expect(wrapper.find("#step-0").exists()).toBe(true);
+  });
+});

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -1,34 +1,37 @@
-import api from './api'
+import api from "./api";
 
 export interface RecipePayload {
   data: {
     attributes: {
-      name?: string
-      description?: string
-    }
+      name?: string;
+      description?: string;
+      estimated_time?: number;
+      steps?: string[];
+      ingredients?: string[];
+    };
     relationships?: {
       author?: {
         data: {
           attributes: {
-            id: number
-          }
-        }
-      }
-    }
-  }
+            id: number;
+          };
+        };
+      };
+    };
+  };
 }
 
 export const getRecipes = (search?: string) =>
-  api.get('/api/v1/recipes', { params: { search } })
+  api.get("/api/v1/recipes", { params: { search } });
 
 export const getRecipe = (id: number, include?: string) =>
-  api.get(`/api/v1/recipes/${id}`, { params: { include } })
+  api.get(`/api/v1/recipes/${id}`, { params: { include } });
 
 export const createRecipe = (payload: RecipePayload) =>
-  api.post('/api/v1/recipes', payload)
+  api.post("/api/v1/recipes", payload);
 
 export const updateRecipe = (id: number, payload: RecipePayload) =>
-  api.patch(`/api/v1/recipes/${id}`, payload)
+  api.patch(`/api/v1/recipes/${id}`, payload);
 
 export const deleteRecipe = (id: number) =>
-  api.delete(`/api/v1/recipes/${id}`, { data: { id } })
+  api.delete(`/api/v1/recipes/${id}`, { data: { id } });

--- a/src/views/RecipeForm.vue
+++ b/src/views/RecipeForm.vue
@@ -1,24 +1,41 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
-import { getRecipe, createRecipe, updateRecipe } from '@/services/recipeService'
+import { onMounted, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import {
+  getRecipe,
+  createRecipe,
+  updateRecipe,
+} from "@/services/recipeService";
 
-defineOptions({ name: 'RecipeFormView' })
+defineOptions({ name: "RecipeFormView" });
 
-const route = useRoute()
-const router = useRouter()
+const route = useRoute();
+const router = useRouter();
 
-const id = route.params.id ? Number(route.params.id) : null
-const name = ref('')
-const description = ref('')
+const id = route.params.id ? Number(route.params.id) : null;
+const name = ref("");
+const description = ref("");
+const estimatedTime = ref<number | null>(null);
+const steps = ref<string[]>([""]);
+const ingredients = ref<string[]>([""]);
 
 onMounted(async () => {
   if (id) {
-    const { data } = await getRecipe(id)
-    name.value = data.name
-    description.value = data.description
+    const { data } = await getRecipe(id, "steps,ingredients");
+    name.value = data.name;
+    description.value = data.description;
+    estimatedTime.value = (data.estimated_time as number) ?? null;
+    steps.value = data.steps?.map(
+      (s: { description: string }) => s.description,
+    ) || [""];
+    ingredients.value = data.ingredients?.map(
+      (i: { name: string }) => i.name,
+    ) || [""];
   }
-})
+});
+
+const addStep = () => steps.value.push("");
+const addIngredient = () => ingredients.value.push("");
 
 const submit = async () => {
   const payload = {
@@ -26,23 +43,26 @@ const submit = async () => {
       attributes: {
         name: name.value,
         description: description.value,
+        estimated_time: estimatedTime.value ?? undefined,
+        steps: steps.value.filter((s) => s.trim().length),
+        ingredients: ingredients.value.filter((i) => i.trim().length),
       },
     },
-  }
+  };
 
   if (id) {
-    await updateRecipe(id, payload)
+    await updateRecipe(id, payload);
   } else {
-    await createRecipe(payload)
+    await createRecipe(payload);
   }
 
-  router.push({ name: 'recipes' })
-}
+  router.push({ name: "recipes" });
+};
 </script>
 
 <template>
   <div>
-    <h1>{{ id ? 'Edit' : 'Create' }} Recipe</h1>
+    <h1>{{ id ? "Edit" : "Create" }} Recipe</h1>
     <form @submit.prevent="submit">
       <div>
         <label for="name">Name</label>
@@ -51,6 +71,37 @@ const submit = async () => {
       <div>
         <label for="description">Description</label>
         <textarea id="description" v-model="description"></textarea>
+      </div>
+      <div>
+        <label for="estimatedTime">Estimated Time (minutes)</label>
+        <input
+          id="estimatedTime"
+          type="number"
+          min="0"
+          v-model.number="estimatedTime"
+        />
+      </div>
+      <div>
+        <label>Ingredients</label>
+        <div v-for="(ingredient, index) in ingredients" :key="index">
+          <input
+            :id="`ingredient-${index}`"
+            v-model="ingredients[index]"
+            placeholder="Ingredient"
+          />
+        </div>
+        <button type="button" @click="addIngredient">Add Ingredient</button>
+      </div>
+      <div>
+        <label>Steps</label>
+        <div v-for="(step, index) in steps" :key="index">
+          <input
+            :id="`step-${index}`"
+            v-model="steps[index]"
+            placeholder="Step description"
+          />
+        </div>
+        <button type="button" @click="addStep">Add Step</button>
       </div>
       <button type="submit">Save</button>
     </form>


### PR DESCRIPTION
## Summary
- allow recipes to include estimated time, steps, and ingredients
- cover recipe form with basic unit test

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a6946c4568833390386a10bd2a5e96